### PR TITLE
Rakefile: do not fail when rake:ci task loading fails

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,6 +23,9 @@ begin
   # load the local tasks
   require_relative "lib/yast/rake_ci"
 rescue LoadError
+  # when building the RPM package at Jenkins the required gems might be missing
+  # at the create tarball step (they are installed later into the OSC chroot),
+  # do not fail in that case
   $stderr.puts "Warning: Loading rake:ci task failed, skipping the task"
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -26,7 +26,9 @@ rescue LoadError
   # when building the RPM package at Jenkins the required gems might be missing
   # at the create tarball step (they are installed later into the OSC chroot),
   # do not fail in that case
-  $stderr.puts "Warning: Loading rake:ci task failed, skipping the task"
+  if !ENV["JENKINS_URL"]
+    $stderr.puts "Warning: Loading rake:ci task failed, skipping the task"
+  end
 end
 
 # remove tarball implementation and create gem for this gemfile

--- a/Rakefile
+++ b/Rakefile
@@ -18,8 +18,13 @@
 #++
 
 require "yast/rake"
-# load the local tasks
-require_relative "lib/yast/rake_ci"
+
+begin
+  # load the local tasks
+  require_relative "lib/yast/rake_ci"
+rescue LoadError
+  $stderr.puts "Warning: Loading rake:ci task failed, skipping the task"
+end
 
 # remove tarball implementation and create gem for this gemfile
 Rake::Task[:tarball].clear


### PR DESCRIPTION
The Jenkins worker is missing some dependant gems, but
we need to make the `osc:build` task pass.
