### PR TITLE
Disable tests during RPM build

### DIFF
--- a/package/gem2rpm.yml
+++ b/package/gem2rpm.yml
@@ -44,8 +44,8 @@
 #   # delete custom files here or do other fancy stuff
 #   install -D -m 0644 %{S:1} %{buildroot}%{_bindir}/gem2rpm-opensuse
 # ## used by gem2rpm
-:testsuite_command: |-
-   (cd %{buildroot}%{gem_base}/gems/%{mod_full_name} && rake --verbose --trace check:ci)
+# :testsuite_command: |-
+#   (cd %{buildroot}%{gem_base}/gems/%{mod_full_name} && rake --verbose --trace check:ci)
 # ## used by gem2rpm
 # :filelist: |-
 #   /usr/bin/gem2rpm-opensuse

--- a/package/rubygem-yast-rake-ci.spec
+++ b/package/rubygem-yast-rake-ci.spec
@@ -66,11 +66,6 @@ is a good idea to move them to a separate gem.
   --no-rdoc --no-ri \
   -f
 
-# MANUAL
-%check
-(cd %{buildroot}%{gem_base}/gems/%{mod_full_name} && rake --verbose --trace check:ci)
-#/ MANUAL
-
 %gem_packages
 
 %changelog


### PR DESCRIPTION
Unfortunately the RPM build fails because we would need to install several `yast-rake` gems (for Ruby 2.1 and 2.2). See the [failed log](https://build.opensuse.org/package/live_build_log/YaST:Head/rubygem-yast-rake-ci/openSUSE_Factory/x86_64). I'm not sure if that's actually possible...

Let's run the tests in the [Jenkins project](https://ci.opensuse.org/view/Yast/job/yast-rake-ci-master/) only.
