### PR TITLE
Fix build with multiple Ruby instances

### DIFF
--- a/package/gem2rpm.yml
+++ b/package/gem2rpm.yml
@@ -45,7 +45,7 @@
 #   install -D -m 0644 %{S:1} %{buildroot}%{_bindir}/gem2rpm-opensuse
 # ## used by gem2rpm
 :testsuite_command: |-
-   (cd %{buildroot}%{gem_base}/gems/%{mod_full_name} && rake --verbose --trace check:ci)
+   (cd %{buildroot}%{gem_base}/gems/%{mod_full_name} && rake.%{rb_default_ruby_suffix} --verbose --trace check:ci)
 # ## used by gem2rpm
 # :filelist: |-
 #   /usr/bin/gem2rpm-opensuse

--- a/package/rubygem-yast-rake-ci.spec
+++ b/package/rubygem-yast-rake-ci.spec
@@ -68,7 +68,7 @@ is a good idea to move them to a separate gem.
 
 # MANUAL
 %check
-(cd %{buildroot}%{gem_base}/gems/%{mod_full_name} && rake --verbose --trace check:ci)
+(cd %{buildroot}%{gem_base}/gems/%{mod_full_name} && rake.%{rb_default_ruby_suffix} --verbose --trace check:ci)
 #/ MANUAL
 
 %gem_packages


### PR DESCRIPTION
Use the system default `rake` for running the tests during RPM build.
